### PR TITLE
Define GNU_SOURCE in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -std=c99 -I$(PWD) -Wall -Werror
 
 KERNEL = os os/irq os/syscall os/sched os/asm_sched os/time
 
-$(KERNEL:%=src/%.o) : CFLAGS += -I$(PWD)/src
+$(KERNEL:%=src/%.o) : CFLAGS += -I$(PWD)/src -D_GNU_SOURCE
 
 image : $(KERNEL:%=src/%.o) src/apps.o
 	$(CC) $(LDFLAGS) -o $@ $^

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 
 #include <stdlib.h>
 #include <stddef.h>

--- a/src/os/irq.c
+++ b/src/os/irq.c
@@ -1,6 +1,4 @@
 
-#define _GNU_SOURCE
-
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>

--- a/src/os/syscall.c
+++ b/src/os/syscall.c
@@ -1,6 +1,4 @@
 
-#define _GNU_SOURCE
-
 #include <assert.h>
 #include <errno.h>
 #include <string.h>

--- a/src/os/time.c
+++ b/src/os/time.c
@@ -1,6 +1,4 @@
 
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <signal.h>
 #include <stdlib.h>


### PR DESCRIPTION
Remove "#define GNU_SOURCE" from files, instead changing Makefile.