### PR TITLE
Exit status

### DIFF
--- a/src/apps.c
+++ b/src/apps.c
@@ -150,7 +150,10 @@ void shell(void *args) {
 
 			int task_id = os_clone(do_task, (void *)&args);
 
-			os_waitpid(task_id);
+			int status = os_waitpid(task_id);
+			if(status != 0) {
+				os_halt(status);
+			}
 
 			args.cmd = strtok_r(NULL, comsep, &saveptr);
 		}

--- a/src/apps.c
+++ b/src/apps.c
@@ -97,7 +97,6 @@ static const struct {
 
 struct params {
 	char *cmd;
-	int res;
 };
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
@@ -116,7 +115,7 @@ static void do_task(void *args) {
 	for (int i = 0; i < ARRAY_SIZE(app_list); ++i) {
 		if (!strcmp(argv[0], app_list[i].name)) {
 
-			p->res = app_list[i].fn(argc, argv);
+			os_exit(app_list[i].fn(argc, argv));
 			return;
 
 		}

--- a/src/os.h
+++ b/src/os.h
@@ -11,7 +11,7 @@ extern int os_waitpid(int task_id);
 
 extern int os_halt(int status);
 
-extern int os_exit();
+extern int os_exit(int status);
 
 extern int os_wait(void);
 

--- a/src/os/sched.c
+++ b/src/os/sched.c
@@ -50,7 +50,7 @@ void task_tramp(sched_task_entry_t entry, void *arg) {
 	irq_enable(IRQ_ALL);
 	entry(arg);
 	// abort();
-	os_exit();
+	os_exit(0);
 }
 
 static void task_init(struct sched_task *task) {

--- a/src/os/sched.h
+++ b/src/os/sched.h
@@ -22,6 +22,7 @@ struct sched_task {
 	char stack[0x10000];
 	enum sched_state state;
 	struct sched_task *parent;
+	int exit_status;
 };
 
 extern int get_task_id(struct sched_task *task);

--- a/src/os/syscall.c
+++ b/src/os/syscall.c
@@ -114,7 +114,7 @@ static long sys_waitpid(int syscall,
 
 	irq_enable(cur);
 
-	return 0;
+	return task->exit_status;
 }
 
 static long sys_halt(int syscall,
@@ -133,7 +133,10 @@ static long sys_exit(int syscall,
 
 	irqmask_t irq = irq_disable();
 
+	int status = (int) arg1;
+
 	struct sched_task *cur_task = sched_current();
+	cur_task->exit_status = status;
 	remove_task(cur_task);
 	sched_notify(cur_task->parent);
 
@@ -226,7 +229,7 @@ int os_halt(int status) {
 }
 
 int os_exit(int status) {
-	return os_syscall(os_syscall_nr_exit, 0, 0, 0, 0, NULL);
+	return os_syscall(os_syscall_nr_exit, status, 0, 0, 0, NULL);
 }
 
 int os_wait(void) {


### PR DESCRIPTION
`os_exit` takes exit status as an argument, `os_waitpid()` eventually returns it. 
Even though replacing all `exit`s with `os_exit` doesn't make much sense right now (because `os_halt`, that calls `exit`, may be called if `os_waitpid` returns something bad), I think, it gives a bit more control.